### PR TITLE
fix locationWithContextErr always true

### DIFF
--- a/response.go
+++ b/response.go
@@ -53,7 +53,7 @@ func (r Response) Clone() Response {
 
 // Write applies the defined HTMX headers to a given response writer.
 func (r Response) Write(w http.ResponseWriter) error {
-	if r.locationWithContextErr != nil {
+	if len(r.locationWithContextErr) > 0 {
 		return errors.Join(r.locationWithContextErr...)
 	}
 


### PR DESCRIPTION
calling LocationWithContext on Response creates a new slice of errors thus always causing the `!= nil` check to always be true.

check for len instead, as a len check on nil slice works just fine